### PR TITLE
Stub EntityManagerInterface and ObjectManager

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -11,8 +11,9 @@ class Plugin implements PluginEntryPointInterface
     public function __invoke(RegistrationInterface $psalm, ?SimpleXMLElement $config = null)
     {
         $psalm->addStubFile(__DIR__ . '/' . 'stubs/Collections.php');
-        $psalm->addStubFile(__DIR__ . '/' . 'stubs/EntityManager.php');
+        $psalm->addStubFile(__DIR__ . '/' . 'stubs/EntityManagerInterface.php');
         $psalm->addStubFile(__DIR__ . '/' . 'stubs/EntityRepository.php');
+        $psalm->addStubFile(__DIR__ . '/' . 'stubs/ObjectManager.php');
         $psalm->addStubFile(__DIR__ . '/' . 'stubs/Paginator.php');
     }
 }

--- a/stubs/EntityManagerInterface.php
+++ b/stubs/EntityManagerInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace Doctrine\ORM;
 
-class EntityManager implements EntityManagerInterface
+class EntityManagerInterface
 {
     /**
      * @template T
@@ -10,14 +10,6 @@ class EntityManager implements EntityManagerInterface
      * @return EntityRepository<T>
      */
     public function getRepository(string $entityName) {}
-
-    /**
-     * @template T
-     * @param class-string $className
-     * @template-typeof T $className
-     * @return Mapping\ClassMetadata<T>
-     */
-    public function getClassMetadata(string $className) {}
 
     /**
      * @template T

--- a/stubs/ObjectManager.php
+++ b/stubs/ObjectManager.php
@@ -1,0 +1,29 @@
+<?php
+namespace Doctrine\ORM;
+
+class ObjectManager
+{
+    /**
+     * @template T
+     * @param class-string $className
+     * @template-typeof T $className
+     * @return ObjectRepository<T>
+     */
+    public function getRepository(string $className) {}
+
+    /**
+     * @template T
+     * @param class-string $className
+     * @template-typeof T $className
+     * @return Mapping\ClassMetadata<T>
+     */
+    public function getClassMetadata(string $className) {}
+
+    /**
+     * @template T
+     * @param class-string $className
+     * @template-typeof T $className
+     * @return ?T
+     */
+    public function find(string $className, $id) {}
+}


### PR DESCRIPTION
In our projects we typehint for `Doctrine\ORM\EntityManagerInterface`, meaning the existing `EntityManager` stub doesn't work. This PR splits the existing `EntityManager` stub into separate `EntityManagerInterface` and `ObjectManager` stubs.

This should have no effect on projects which were using the `EntityManager` stub previously.