### PR TITLE
Stub ClassMetadata::getAssociationTargetClass()

### DIFF
--- a/stubs/ClassMetadata.php
+++ b/stubs/ClassMetadata.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Common\Persistence\Mapping;
+
+interface ClassMetadata
+{
+    /**
+     * @return class-string
+     */
+    public function getAssociationTargetClass($assocName);
+}


### PR DESCRIPTION
This just stubs the `ClassMetadata::getAssociationTargetClass()` method to hint the return type as `class-string`.

**Example code**

```php
$associationClassMetadata = $entityManager->getClassMetadata(
    $classMetadata->getAssociationTargetClass($associationName)
);
```

**Without this stub**

```
$ vendor/bin/psalm src/file.php
Scanning files...
Analyzing files...

ERROR: ArgumentTypeCoercion - src/file.php:79:17 - Argument 1 of Doctrine\ORM\EntityManagerInterface::getclassmetadata expects class-string, parent type string provided
                $classMetadata->getAssociationTargetClass($associationName)


------------------------------
1 errors found
------------------------------

Checks took 2.85 seconds and used 244.993MB of memory
Psalm was able to infer types for 92.9400% of the codebase
```

**With this stub**

```
$ vendor/bin/psalm src/file.php 
Scanning files...
Analyzing files...

------------------------------
No errors found!
------------------------------

Checks took 3.99 seconds and used 246.643MB of memory
Psalm was able to infer types for 92.9398% of the codebase
```