### PR TITLE
Added `Doctrine\ORM\Mapping\ClassMetadataInfo` with single $table field

### DIFF
--- a/stubs/ClassMetadataInfo.php
+++ b/stubs/ClassMetadataInfo.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Doctrine\ORM\Mapping;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+
+class ClassMetadataInfo implements ClassMetadata
+{
+    /**
+     * @var array{name: string, schema: string, indexes: array, uniqueConstraints: array}
+     */
+    public $table;
+}


### PR DESCRIPTION
For my project I was missing `Doctrine\ORM\Mapping\ClassMetadataInfo::$table['name']`

I added all array keys but did not bother researching what exact type of `indexes` and `uniqueConstraints` is.

Please let me know if this change is good enough as-is, or I must better type those keys.

Thanks.