### PR TITLE
ClassMetadataInfo::sequenceGeneratorDefinition

### DIFF
--- a/stubs/ClassMetadataInfo.php
+++ b/stubs/ClassMetadataInfo.php
@@ -10,4 +10,9 @@ class ClassMetadataInfo implements ClassMetadata
      * @var array{name: string, schema: string, indexes: array, uniqueConstraints: array}
      */
     public $table;
+
+    /**
+     * @var array{sequenceName: string, allocationSize: int, initialValue: int}
+     */
+    public $sequenceGeneratorDefinition;
 }


### PR DESCRIPTION
Could you please merge this one as well.

The definition is taken from the official docblock:

```
    /**
     * READ-ONLY: The definition of the sequence generator of this class. Only used for the
     * SEQUENCE generation strategy.
     *
     * The definition has the following structure:
     * <code>
     * array(
     *     'sequenceName' => 'name',
     *     'allocationSize' => 20,
     *     'initialValue' => 1
     * )
     * </code>
     *
     * @var array
     *
     * @todo Merge with tableGeneratorDefinition into generic generatorDefinition
     */
    public $sequenceGeneratorDefinition;
```

PS: should also we mark things as `@psalm-readonly`?