### PR TITLE
Fix Doctrine\Common\Persistence deprecations

### DIFF
--- a/bundle-stubs/ServiceEntityRepository.phpstub
+++ b/bundle-stubs/ServiceEntityRepository.phpstub
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityRepository;
 
 /**

--- a/bundle-stubs/ServiceEntityRepository.phpstub
+++ b/bundle-stubs/ServiceEntityRepository.phpstub
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityRepository;
-use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * @template T

--- a/bundle-stubs/ServiceEntityRepository.phpstub
+++ b/bundle-stubs/ServiceEntityRepository.phpstub
@@ -2,8 +2,8 @@
 
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * @template T

--- a/stubs/ClassMetadata.phpstub
+++ b/stubs/ClassMetadata.phpstub
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Common\Persistence\Mapping;
+namespace Doctrine\Persistence\Mapping;
 
 /** @template T */
 interface ClassMetadata

--- a/stubs/ClassMetadataInfo.phpstub
+++ b/stubs/ClassMetadataInfo.phpstub
@@ -2,7 +2,7 @@
 
 namespace Doctrine\ORM\Mapping;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 
 class ClassMetadataInfo implements ClassMetadata
 {

--- a/stubs/EntityManagerInterface.phpstub
+++ b/stubs/EntityManagerInterface.phpstub
@@ -2,7 +2,7 @@
 
 namespace Doctrine\ORM;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 
 interface EntityManagerInterface extends ObjectManager
 {

--- a/stubs/EntityRepository.phpstub
+++ b/stubs/EntityRepository.phpstub
@@ -5,7 +5,7 @@ namespace Doctrine\ORM;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 
 /**
  * @template T

--- a/stubs/ObjectManager.phpstub
+++ b/stubs/ObjectManager.phpstub
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Common\Persistence;
+namespace Doctrine\Persistence;
 
 interface ObjectManager
 {

--- a/stubs/ObjectRepository.phpstub
+++ b/stubs/ObjectRepository.phpstub
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Common\Persistence;
+namespace Doctrine\Persistence;
 
 /** @template T */
 interface ObjectRepository

--- a/tests/acceptance/ObjectManager.feature
+++ b/tests/acceptance/ObjectManager.feature
@@ -19,7 +19,7 @@ Feature: ObjectManager
     And I have the following code preamble
       """
       <?php
-      use Doctrine\Common\Persistence\ObjectManager;
+      use Doctrine\Persistence\ObjectManager;
 
       interface I {}
 
@@ -41,8 +41,8 @@ Feature: ObjectManager
       """
     When I run Psalm
     Then I see these errors
-      | Type            | Message                                                                                    |
-      | InvalidArgument | Argument 1 of atan expects float, Doctrine\Common\Persistence\ObjectRepository<I> provided |
+      | Type            | Message                                                                             |
+      | InvalidArgument | Argument 1 of atan expects float, Doctrine\Persistence\ObjectRepository<I> provided |
 
   @ObjectManager::getRepository
   Scenario: Calling getRepository with a wrong argument type
@@ -52,8 +52,8 @@ Feature: ObjectManager
       """
     When I run Psalm
     Then I see these errors
-      | Type                  | Message                                                                                                        |
-      | InvalidScalarArgument | Argument 1 of Doctrine\Common\Persistence\ObjectManager::getRepository expects class-string, int(123) provided |
+      | Type                  | Message                                                                                                 |
+      | InvalidScalarArgument | Argument 1 of Doctrine\Persistence\ObjectManager::getRepository expects class-string, int(123) provided |
 
   @ObjectManager::getClassMetadata
   Scenario: Calling getClassMetadata with a class-string argument
@@ -63,8 +63,8 @@ Feature: ObjectManager
       """
     When I run Psalm
     Then I see these errors
-      | Type            | Message                                                                                         |
-      | InvalidArgument | Argument 1 of atan expects float, Doctrine\Common\Persistence\Mapping\ClassMetadata<I> provided |
+      | Type            | Message                                                                                  |
+      | InvalidArgument | Argument 1 of atan expects float, Doctrine\Persistence\Mapping\ClassMetadata<I> provided |
 
   @ObjectManager::getClassMetadata
   Scenario: Calling getClassMetadata with a wrong argument type
@@ -74,8 +74,8 @@ Feature: ObjectManager
       """
     When I run Psalm
     Then I see these errors
-      | Type                  | Message                                                                                                           |
-      | InvalidScalarArgument | Argument 1 of Doctrine\Common\Persistence\ObjectManager::getClassMetadata expects class-string, int(123) provided |
+      | Type                  | Message                                                                                                    |
+      | InvalidScalarArgument | Argument 1 of Doctrine\Persistence\ObjectManager::getClassMetadata expects class-string, int(123) provided |
 
   @ObjectManager::find
   Scenario: Calling find with a class-string argument
@@ -96,5 +96,5 @@ Feature: ObjectManager
       """
     When I run Psalm
     Then I see these errors
-      | Type                  | Message                                                                                               |
-      | InvalidScalarArgument | Argument 1 of Doctrine\Common\Persistence\ObjectManager::find expects class-string, int(123) provided |
+      | Type                  | Message                                                                                        |
+      | InvalidScalarArgument | Argument 1 of Doctrine\Persistence\ObjectManager::find expects class-string, int(123) provided |

--- a/tests/acceptance/ObjectRepository.feature
+++ b/tests/acceptance/ObjectRepository.feature
@@ -19,7 +19,7 @@ Feature: ObjectRepository
     And I have the following code preamble
       """
       <?php
-      use Doctrine\Common\Persistence\ObjectRepository;
+      use Doctrine\Persistence\ObjectRepository;
 
       interface I {
         /** @return void */

--- a/tests/acceptance/ServiceEntityRepository.feature
+++ b/tests/acceptance/ServiceEntityRepository.feature
@@ -14,6 +14,13 @@ Feature: ServiceEntityRepository
         <plugins>
           <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin" />
         </plugins>
+        <issueHandlers>
+          <DeprecatedInterface>
+            <errorLevel type="suppress">
+              <referencedClass name="Doctrine\Common\Persistence\ObjectRepository"/>
+            </errorLevel>
+          </DeprecatedInterface>
+        </issueHandlers>
       </psalm>
       """
     And I have the following code preamble

--- a/tests/acceptance/ServiceEntityRepository.feature
+++ b/tests/acceptance/ServiceEntityRepository.feature
@@ -36,7 +36,7 @@ Feature: ServiceEntityRepository
       Given I have the "doctrine/persistence" package satisfying the "< 1.3"
       And I have the following code
         """
-        use Doctrine\Common\Persistence\ManagerRegistry as RegistryInterface;
+        use Doctrine\Persistence\ManagerRegistry;
 
         interface I {}
         /**
@@ -73,7 +73,7 @@ Feature: ServiceEntityRepository
          * @psalm-suppress PropertyNotSetInConstructor
          */
         class IRepository extends ServiceEntityRepository {
-          public function __construct(RegistryInterface $registry) {
+          public function __construct(ManagerRegistry $registry) {
             parent::__construct($registry, I::class);
           }
         }

--- a/tests/acceptance/ServiceEntityRepository.feature
+++ b/tests/acceptance/ServiceEntityRepository.feature
@@ -36,7 +36,7 @@ Feature: ServiceEntityRepository
       Given I have the "doctrine/persistence" package satisfying the "< 1.3"
       And I have the following code
         """
-        use Doctrine\Persistence\ManagerRegistry;
+        use Doctrine\Common\Persistence\ManagerRegistry as RegistryInterface;
 
         interface I {}
         /**
@@ -73,7 +73,7 @@ Feature: ServiceEntityRepository
          * @psalm-suppress PropertyNotSetInConstructor
          */
         class IRepository extends ServiceEntityRepository {
-          public function __construct(ManagerRegistry $registry) {
+          public function __construct(RegistryInterface $registry) {
             parent::__construct($registry, I::class);
           }
         }


### PR DESCRIPTION
Just a basic find and replace of `Doctrine\Common\Persistence` with `Doctrine\Persistence`.

There are two failing tests but they are unrelated and were failing before.