### PR TITLE
adding Doctrine standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - if [[ "$DEPS" = 'low' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS --prefer-lowest --prefer-stable update; fi
   - if [[ "$DEPS" = 'stable' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS --prefer-stable update; fi
 
-script: vendor/bin/codecept run -v
+script: composer check
 
 env:
     matrix:

--- a/Plugin.php
+++ b/Plugin.php
@@ -4,9 +4,13 @@ namespace Weirdan\DoctrinePsalmPlugin;
 
 use OutOfBoundsException;
 use PackageVersions\Versions;
-use SimpleXMLElement;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
+use SimpleXMLElement;
+
+use function array_merge;
+use function class_exists;
+use function glob;
 
 class Plugin implements PluginEntryPointInterface
 {
@@ -29,7 +33,7 @@ class Plugin implements PluginEntryPointInterface
     /** @return string[] */
     private function getBundleStubs(): array
     {
-        if (!$this->hasPackage('doctrine/doctrine-bundle')) {
+        if (! $this->hasPackage('doctrine/doctrine-bundle')) {
             return [];
         }
 
@@ -43,6 +47,7 @@ class Plugin implements PluginEntryPointInterface
         } catch (OutOfBoundsException $e) {
             return false;
         }
+
         return true;
     }
 

--- a/bundle-stubs/ServiceEntityRepository.php
+++ b/bundle-stubs/ServiceEntityRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Doctrine\Bundle\DoctrineBundle\Repository;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -13,6 +14,7 @@ class ServiceEntityRepository extends EntityRepository implements ServiceEntityR
     /**
      * @param string $entityClass The class name of the entity this repository manages
      */
-    public function __construct(ManagerRegistry $registry, $entityClass) {}
+    public function __construct(ManagerRegistry $registry, $entityClass)
+    {
+    }
 }
-

--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,15 @@
         "doctrine/doctrine-bundle": "^1.11",
         "phly/keep-a-changelog": "^2.1",
         "doctrine/coding-standard": "^7.0"
+    },
+    "scripts": {
+        "check": [
+            "@test",
+            "@psalm",
+            "@phpcs"
+        ],
+        "test": "codecept --colors run -v",
+        "psalm": "psalm",
+        "phpcs": "phpcs --colors"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,9 +44,9 @@
     },
     "scripts": {
         "check": [
-            "@test",
+            "@phpcs",
             "@psalm",
-            "@phpcs"
+            "@test"
         ],
         "test": "codecept --colors run -v",
         "psalm": "psalm",

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
     "scripts": {
         "check": [
             "@phpcs",
-            "@psalm",
-            "@test"
+            "@test",
+            "@psalm"
         ],
         "test": "codecept --colors run -v",
         "psalm": "psalm",

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "composer/semver": "^1.4",
         "weirdan/codeception-psalm-module": "^0.2.2",
         "doctrine/doctrine-bundle": "^1.11",
-        "phly/keep-a-changelog": "^2.1"
+        "phly/keep-a-changelog": "^2.1",
+        "doctrine/coding-standard": "^7.0"
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,7 +7,29 @@
     <!-- Paths to check -->
     <file>Plugin.php</file>
 
+    <!-- Include full Doctrine Coding Standard -->
+    <rule ref="Doctrine">
+        <!-- inapplicable for this project -->
+        <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
+        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
+        <exclude name="quiz.Classes.ClassFileName.NoMatch" />
+        <exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix" />
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
+        <exclude name="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore" />
+        <exclude name="Squiz.Classes.ClassFileName.NoMatch" />
 
+        <!-- conflicts with other rules -->
+        <exclude name="SlevomatCodingStandard.Namespaces.NamespaceSpacing" /> <!-- PSR12.Files.FileHeader -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" /> <!-- PSR12.Functions.ReturnTypeDeclaration -->
+    </rule>
+    
     <!-- inherit rules from: -->
     <rule ref="PSR12"/>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,23 +15,12 @@
         <!-- inapplicable for this project -->
         <exclude name="Generic.Strings.UnnecessaryStringConcat.Found" />
         <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
-        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
-        <exclude name="Squiz.Classes.ClassFileName.NoMatch" />
-        <exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
-        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix" />
-        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint" />
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint" />
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
+	<exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
+	<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
         <exclude name="SlevomatCodingStandard.Namespaces.UseSpacing.IncorrectLinesCountBetweenDifferentTypeOfUse" />
-        <exclude name="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore" />
 
         <!-- conflicts with other rules -->
-        <exclude name="SlevomatCodingStandard.Namespaces.NamespaceSpacing" /> <!-- PSR12.Files.FileHeader -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" /> <!-- PSR12.Functions.ReturnTypeDeclaration -->
+	<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" /> <!-- [> PSR12.Functions.ReturnTypeDeclaration <] -->
     </rule>
     
     <!-- inherit rules from: -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,7 +28,6 @@
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
         <exclude name="SlevomatCodingStandard.Namespaces.UseSpacing.IncorrectLinesCountBetweenDifferentTypeOfUse" />
         <exclude name="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore" />
-        <exclude name="Squiz.Classes.ClassFileName.NoMatch" />
 
         <!-- conflicts with other rules -->
         <exclude name="SlevomatCodingStandard.Namespaces.NamespaceSpacing" /> <!-- PSR12.Files.FileHeader -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,13 +18,10 @@
     <rule ref="Doctrine">
         <!-- inapplicable for this project -->
         <exclude name="Generic.Strings.UnnecessaryStringConcat.Found" />
-        <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
         <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
-        <exclude name="Squiz.Classes.ClassFileName.NoMatch" />
         <exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix" />
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint" />
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint" />
@@ -34,8 +31,7 @@
         <exclude name="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore" />
 
         <!-- conflicts with other rules -->
-        <exclude name="SlevomatCodingStandard.Namespaces.NamespaceSpacing" /> <!-- PSR12.Files.FileHeader -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" /> <!-- PSR12.Functions.ReturnTypeDeclaration -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" /> <!-- [> PSR12.Functions.ReturnTypeDeclaration <] -->
     </rule>
     
     <!-- inherit rules from: -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,14 +9,18 @@
 
     <!-- Paths to check -->
     <file>Plugin.php</file>
+    <file>stubs</file>
+    <file>bundle-stubs</file>
+    <file>tests</file>
+    <exclude-pattern>*/tests/_run/*</exclude-pattern>
 
     <!-- Include full Doctrine Coding Standard -->
     <rule ref="Doctrine">
         <!-- inapplicable for this project -->
         <exclude name="Generic.Strings.UnnecessaryStringConcat.Found" />
         <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
-	<exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
-	<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
         <exclude name="SlevomatCodingStandard.Namespaces.UseSpacing.IncorrectLinesCountBetweenDifferentTypeOfUse" />
 
         <!-- conflicts with other rules -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="invajo">
+<ruleset
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+    name="doctrine-psalm-plugin">
     <!-- display progress -->
     <arg value="p"/>
     <arg name="colors"/>
@@ -10,9 +13,10 @@
     <!-- Include full Doctrine Coding Standard -->
     <rule ref="Doctrine">
         <!-- inapplicable for this project -->
+        <exclude name="Generic.Strings.UnnecessaryStringConcat.Found" />
         <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
         <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
-        <exclude name="quiz.Classes.ClassFileName.NoMatch" />
+        <exclude name="Squiz.Classes.ClassFileName.NoMatch" />
         <exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix" />
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
@@ -22,6 +26,7 @@
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint" />
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
+        <exclude name="SlevomatCodingStandard.Namespaces.UseSpacing.IncorrectLinesCountBetweenDifferentTypeOfUse" />
         <exclude name="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore" />
         <exclude name="Squiz.Classes.ClassFileName.NoMatch" />
 
@@ -47,6 +52,12 @@
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false"/>
+        </properties>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing.UseSpacingSniff">
+        <properties>
+            <property name="linesCountBetweenUseTypes" value="1"/>
         </properties>
     </rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,12 +19,23 @@
         <!-- inapplicable for this project -->
         <exclude name="Generic.Strings.UnnecessaryStringConcat.Found" />
         <exclude name="PSR1.Classes.ClassDeclaration.MultipleClasses" />
+        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
+        <exclude name="Squiz.Classes.ClassFileName.NoMatch" />
+        <exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix" />
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
         <exclude name="SlevomatCodingStandard.Namespaces.UseSpacing.IncorrectLinesCountBetweenDifferentTypeOfUse" />
+        <exclude name="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore" />
 
         <!-- conflicts with other rules -->
-	<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" /> <!-- [> PSR12.Functions.ReturnTypeDeclaration <] -->
+        <exclude name="SlevomatCodingStandard.Namespaces.NamespaceSpacing" /> <!-- PSR12.Files.FileHeader -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing" /> <!-- PSR12.Functions.ReturnTypeDeclaration -->
     </rule>
     
     <!-- inherit rules from: -->

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -9,11 +9,14 @@
         <directory name="." />
         <ignoreFiles>
             <directory name="vendor" />
-	    <directory name="stubs" />
+            <directory name="stubs" />
+            <directory name="bundle-stubs" />
+            <directory name="tests/_support/_generated" />
+            <directory name="tests/_run" />
         </ignoreFiles>
     </projectFiles>
     <plugins>
-	    <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin"/>
+        <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin"/>
     </plugins>
 
 </psalm>

--- a/stubs/ClassMetadata.php
+++ b/stubs/ClassMetadata.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Common\Persistence\Mapping;
 
+/** @template T */
 interface ClassMetadata
 {
     /**

--- a/stubs/ClassMetadataInfo.php
+++ b/stubs/ClassMetadataInfo.php
@@ -6,13 +6,9 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 
 class ClassMetadataInfo implements ClassMetadata
 {
-    /**
-     * @var array{name: string, schema: string, indexes: array, uniqueConstraints: array}
-     */
+    /** @var array{name: string, schema: string, indexes: array, uniqueConstraints: array} */
     public $table;
 
-    /**
-     * @var array{sequenceName: string, allocationSize: int, initialValue: int}
-     */
+    /** @var array{sequenceName: string, allocationSize: int, initialValue: int} */
     public $sequenceGeneratorDefinition;
 }

--- a/stubs/EntityManager.php
+++ b/stubs/EntityManager.php
@@ -1,30 +1,44 @@
 <?php
+
 namespace Doctrine\ORM;
+
 class EntityManager implements EntityManagerInterface
 {
     /**
-     * @template T
      * @param class-string $entityName
-     * @template-typeof T $entityName
+     *
      * @return EntityRepository<T>
+     *
+     * @template T
+     * @template-typeof T $entityName
      */
-    public function getRepository(string $entityName) {}
+    public function getRepository(string $entityName)
+    {
+    }
 
     /**
-     * @template T
      * @param class-string $entityName
-     * @template-typeof T $entityName
-     * @param mixed $id
+     * @param mixed        $id
+     *
      * @return ?T
+     *
+     * @template T
+     * @template-typeof T $entityName
      */
-    public function find(string $entityName, $id, ?int $lockMode = null, ?int $lockVersion = null) {}
+    public function find(string $entityName, $id, ?int $lockMode = null, ?int $lockVersion = null)
+    {
+    }
 
     /**
-     * @template T
      * @param class-string $entityName
-     * @template-typeof T $entityName
-     * @param mixed $id
+     * @param mixed        $id
+     *
      * @return T
+     *
+     * @template T
+     * @template-typeof T $entityName
      */
-    public function getReference(string $entityName, $id) {}
+    public function getReference(string $entityName, $id)
+    {
+    }
 }

--- a/stubs/EntityManagerInterface.php
+++ b/stubs/EntityManagerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Doctrine\ORM;
 
 use Doctrine\Common\Persistence\ObjectManager;
@@ -6,28 +7,34 @@ use Doctrine\Common\Persistence\ObjectManager;
 interface EntityManagerInterface extends ObjectManager
 {
     /**
-     * @template T
      * @param class-string $entityName
-     * @template-typeof T $entityName
+     *
      * @return EntityRepository<T>
+     *
+     * @template T
+     * @template-typeof T $entityName
      */
     public function getRepository(string $entityName);
 
     /**
-     * @template T
      * @param class-string $entityName
-     * @template-typeof T $entityName
-     * @param mixed $id
+     * @param mixed        $id
+     *
      * @return ?T
+     *
+     * @template T
+     * @template-typeof T $entityName
      */
     public function find(string $entityName, $id, ?int $lockMode = null, ?int $lockVersion = null);
 
     /**
-     * @template T
      * @param class-string $entityName
-     * @template-typeof T $entityName
-     * @param mixed $id
+     * @param mixed        $id
+     *
      * @return T
+     *
+     * @template T
+     * @template-typeof T $entityName
      */
     public function getReference(string $entityName, $id);
 }

--- a/stubs/EntityRepository.php
+++ b/stubs/EntityRepository.php
@@ -1,8 +1,9 @@
 <?php
+
 namespace Doctrine\ORM;
 
-use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Collections\Selectable;
+use Doctrine\Common\Persistence\ObjectRepository;
 
 /**
  * @template T
@@ -11,7 +12,6 @@ use Doctrine\Common\Collections\Selectable;
  */
 class EntityRepository implements ObjectRepository, Selectable
 {
-
     /** @var string */
     protected $_entityName;
 
@@ -21,26 +21,38 @@ class EntityRepository implements ObjectRepository, Selectable
     /** @var Mapping\ClassMetadata */
     protected $_class;
 
-
     /** @param Mapping\ClassMetadata<T> $class */
-    public function __construct(EntityManagerInterface $em, Mapping\ClassMetadata $class) {}
+    public function __construct(EntityManagerInterface $em, Mapping\ClassMetadata $class)
+    {
+    }
 
     /**
      * @param ?int $lockMode
      * @param ?int $lockVersion
+     *
      * @return ?T
      */
-    public function find($id, $lockMode = null, $lockVersion = null) {}
+    public function find($id, $lockMode = null, $lockVersion = null)
+    {
+    }
 
     /** @return list<T> */
-    public function findAll() {}
+    public function findAll()
+    {
+    }
+
     /**
-     * @return list<T>
      * @param ?int $limit
      * @param ?int $offset
+     *
+     * @return list<T>
      */
-    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null) {}
+    public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null)
+    {
+    }
 
     /** @return ?T */
-    public function findOneBy(array $criteria, ?array $orderBy = null) {}
+    public function findOneBy(array $criteria, ?array $orderBy = null)
+    {
+    }
 }

--- a/stubs/Expr.php
+++ b/stubs/Expr.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Doctrine\ORM\Query;
 
 class Expr
@@ -6,10 +7,14 @@ class Expr
     /**
      * @param Expr\Comparison|Expr\Func|Expr\Andx|Expr\Orx|string ...$x
      */
-    public function andX(...$x): Expr\Andx {}
+    public function andX(...$x): Expr\Andx
+    {
+    }
 
     /**
      * @param Expr\Comparison|Expr\Func|Expr\Andx|Expr\Orx|string ...$x
      */
-    public function orX(...$x): Expr\Orx {}
+    public function orX(...$x): Expr\Orx
+    {
+    }
 }

--- a/stubs/ObjectManager.php
+++ b/stubs/ObjectManager.php
@@ -1,34 +1,42 @@
 <?php
+
 namespace Doctrine\Common\Persistence {
     interface ObjectManager
     {
         /**
-         * @template T
          * @param class-string $className
-         * @template-typeof T $className
+         *
          * @return ObjectRepository<T>
+         *
+         * @template T
+         * @template-typeof T $className
          */
         public function getRepository(string $className);
 
         /**
-         * @template T
          * @param class-string $className
-         * @template-typeof T $className
+         *
          * @return Mapping\ClassMetadata<T>
+         *
+         * @template T
+         * @template-typeof T $className
          */
         public function getClassMetadata(string $className);
 
         /**
-         * @template T
          * @param class-string $className
-         * @template-typeof T $className
+         *
          * @return ?T
+         *
+         * @template T
+         * @template-typeof T $className
          */
         public function find(string $className, $id);
     }
 }
-
 namespace Doctrine\Common\Persistence\Mapping {
     /** @template T */
-    interface ClassMetadata {}
+    interface ClassMetadata
+    {
+    }
 }

--- a/stubs/ObjectManager.php
+++ b/stubs/ObjectManager.php
@@ -1,42 +1,36 @@
 <?php
 
-namespace Doctrine\Common\Persistence {
-    interface ObjectManager
-    {
-        /**
-         * @param class-string $className
-         *
-         * @return ObjectRepository<T>
-         *
-         * @template T
-         * @template-typeof T $className
-         */
-        public function getRepository(string $className);
+namespace Doctrine\Common\Persistence;
 
-        /**
-         * @param class-string $className
-         *
-         * @return Mapping\ClassMetadata<T>
-         *
-         * @template T
-         * @template-typeof T $className
-         */
-        public function getClassMetadata(string $className);
+interface ObjectManager
+{
+    /**
+     * @param class-string $className
+     *
+     * @return ObjectRepository<T>
+     *
+     * @template T
+     * @template-typeof T $className
+     */
+    public function getRepository(string $className);
 
-        /**
-         * @param class-string $className
-         *
-         * @return ?T
-         *
-         * @template T
-         * @template-typeof T $className
-         */
-        public function find(string $className, $id);
-    }
-}
-namespace Doctrine\Common\Persistence\Mapping {
-    /** @template T */
-    interface ClassMetadata
-    {
-    }
+    /**
+     * @param class-string $className
+     *
+     * @return Mapping\ClassMetadata<T>
+     *
+     * @template T
+     * @template-typeof T $className
+     */
+    public function getClassMetadata(string $className);
+
+    /**
+     * @param class-string $className
+     *
+     * @return ?T
+     *
+     * @template T
+     * @template-typeof T $className
+     */
+    public function find(string $className, $id);
 }

--- a/stubs/ObjectRepository.php
+++ b/stubs/ObjectRepository.php
@@ -1,8 +1,10 @@
 <?php
+
 namespace Doctrine\Common\Persistence;
 
 /** @template T */
-interface ObjectRepository {
+interface ObjectRepository
+{
     /** @return ?T */
     public function find($id);
 
@@ -10,9 +12,10 @@ interface ObjectRepository {
     public function findAll();
 
     /**
-     * @return list<T>
      * @param ?int $limit
      * @param ?int $offset
+     *
+     * @return list<T>
      */
     public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null);
 

--- a/stubs/QueryBuilder.php
+++ b/stubs/QueryBuilder.php
@@ -11,50 +11,66 @@ use Doctrine\ORM\Query\Expr;
 class QueryBuilder
 {
     /**
-     * @param null|_SelectExpr|_SelectExpr[] $select
-     * @param _SelectExpr ...$selects
+     * @param _SelectExpr|_SelectExpr[]|null $select
+     * @param _SelectExpr                    ...$selects
      */
-    public function select($select = null, ...$selects): self {}
+    public function select($select = null, ...$selects): self
+    {
+    }
 
     /**
-     * @param null|_SelectExpr|_SelectExpr[] $select
-     * @param _SelectExpr ...$selects
+     * @param _SelectExpr|_SelectExpr[]|null $select
+     * @param _SelectExpr                    ...$selects
      */
-    public function addSelect($select = null, ...$selects): self {}
-
-    /**
-     * @param _WhereExpr|_WhereExpr[] $predicate
-     * @param _WhereExpr ...$predicates
-     */
-    public function where($predicate, ...$predicates): self {}
-
-    /**
-     * @param _WhereExpr|_WhereExpr[] $predicate
-     * @param _WhereExpr ...$predicates
-     */
-    public function andWhere($predicate, ...$predicates): self {}
+    public function addSelect($select = null, ...$selects): self
+    {
+    }
 
     /**
      * @param _WhereExpr|_WhereExpr[] $predicate
-     * @param _WhereExpr ...$predicates
+     * @param _WhereExpr              ...$predicates
      */
-    public function orWhere($predicate, ...$predicates): self {}
+    public function where($predicate, ...$predicates): self
+    {
+    }
 
     /**
      * @param _WhereExpr|_WhereExpr[] $predicate
-     * @param _WhereExpr ...$predicates
+     * @param _WhereExpr              ...$predicates
      */
-    public function having($predicate, ...$predicates): self {}
+    public function andWhere($predicate, ...$predicates): self
+    {
+    }
 
     /**
      * @param _WhereExpr|_WhereExpr[] $predicate
-     * @param _WhereExpr ...$predicates
+     * @param _WhereExpr              ...$predicates
      */
-    public function andHaving($predicate, ...$predicates): self {}
+    public function orWhere($predicate, ...$predicates): self
+    {
+    }
 
     /**
      * @param _WhereExpr|_WhereExpr[] $predicate
-     * @param _WhereExpr ...$predicates
+     * @param _WhereExpr              ...$predicates
      */
-    public function orHaving($predicate, ...$predicates): self {}
+    public function having($predicate, ...$predicates): self
+    {
+    }
+
+    /**
+     * @param _WhereExpr|_WhereExpr[] $predicate
+     * @param _WhereExpr              ...$predicates
+     */
+    public function andHaving($predicate, ...$predicates): self
+    {
+    }
+
+    /**
+     * @param _WhereExpr|_WhereExpr[] $predicate
+     * @param _WhereExpr              ...$predicates
+     */
+    public function orHaving($predicate, ...$predicates): self
+    {
+    }
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -1,28 +1,8 @@
 <?php
+
 namespace Weirdan\DoctrinePsalmPlugin\Tests;
 
-use Behat\Gherkin\Node\TableNode;
-use Codeception\Exception\TestRuntimeException;
-use Doctrine\Common\Collections\ArrayCollection;
-use PHPUnit\Framework\Assert;
-
-/**
- * Inherited Methods
- * @method void wantToTest($text)
- * @method void wantTo($text)
- * @method void execute($callable)
- * @method void expectTo($prediction)
- * @method void expect($prediction)
- * @method void amGoingTo($argumentation)
- * @method void am($role)
- * @method void lookForwardTo($achieveValue)
- * @method void comment($description)
- * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
- *
- * @SuppressWarnings(PHPMD)
-*/
 class AcceptanceTester extends \Codeception\Actor
 {
     use _generated\AcceptanceTesterActions;
-
 }

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -2,7 +2,9 @@
 
 namespace Weirdan\DoctrinePsalmPlugin\Tests;
 
-class AcceptanceTester extends \Codeception\Actor
+use Codeception\Actor;
+
+class AcceptanceTester extends Actor
 {
     use _generated\AcceptanceTesterActions;
 }

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -1,9 +1,12 @@
 <?php
+
 namespace Weirdan\DoctrinePsalmPlugin\Tests\Helper;
+
+use Codeception\Module;
 
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
-class Acceptance extends \Codeception\Module
+class Acceptance extends Module
 {
 }


### PR DESCRIPTION
Tried to add Doctrine standard as suggested in #20.

I added the doctrine ruleset and then excluded all rules that could not be applied (mainly types in signatures that would make the stubs different from doctrine).

There was two rules that conflicted, I prefered to exclude the new rules from doctrine for 2 reasons:
- it changes less things
- PSR12 is fairly new and its scope aims to be larger than doctrine

Please tell me if some rules don't make sense or should be excluded