### PR TITLE
Stubbing DBAL QueryBuilder

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -12,6 +12,8 @@ use function array_merge;
 use function class_exists;
 use function glob;
 
+use const GLOB_BRACE;
+
 class Plugin implements PluginEntryPointInterface
 {
     /** @return void */
@@ -27,7 +29,7 @@ class Plugin implements PluginEntryPointInterface
     /** @return string[] */
     private function getStubFiles(): array
     {
-        return glob(__DIR__ . '/' . 'stubs/*.php');
+        return glob(__DIR__ . '/' . 'stubs/{,*/}*.php', GLOB_BRACE);
     }
 
     /** @return string[] */

--- a/stubs/DBAL/QueryBuilder.php
+++ b/stubs/DBAL/QueryBuilder.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Doctrine\DBAL\Query;
+
+/**
+ * @psalm-type _WhereExpr=Expression\CompositeExpression|string
+ * @psalm-type _SelectExpr=string
+ * @psalm-type _GroupExpr=string
+ */
+class QueryBuilder
+{
+    /**
+     * @param _SelectExpr|_SelectExpr[]|null $select
+     * @param _SelectExpr                    ...$selects
+     */
+    public function select($select = null, ...$selects): self
+    {
+    }
+
+    /**
+     * @param _SelectExpr|_SelectExpr[]|null $select
+     * @param _SelectExpr                    ...$selects
+     */
+    public function addSelect($select = null, ...$selects): self
+    {
+    }
+
+    /**
+     * @param _WhereExpr $predicate
+     * @param _WhereExpr ...$predicates
+     */
+    public function where($predicate, ...$predicates): self
+    {
+    }
+
+    /**
+     * @param _WhereExpr $predicate
+     * @param _WhereExpr ...$predicates
+     */
+    public function andWhere($predicate, ...$predicates): self
+    {
+    }
+
+    /**
+     * @param _WhereExpr $predicate
+     * @param _WhereExpr ...$predicates
+     */
+    public function orWhere($predicate, ...$predicates): self
+    {
+    }
+
+    /**
+     * @param _GroupExpr|_GroupExpr[] $predicate
+     * @param _GroupExpr              ...$predicates
+     */
+    public function groupBy($predicate, ...$predicates): self
+    {
+    }
+
+    /**
+     * @param _GroupExpr|_GroupExpr[] $predicate
+     * @param _GroupExpr              ...$predicates
+     */
+    public function addGroupBy($predicate, ...$predicates): self
+    {
+    }
+
+    /**
+     * @param _WhereExpr $predicate
+     * @param _WhereExpr ...$predicates
+     */
+    public function having($predicate, ...$predicates): self
+    {
+    }
+
+    /**
+     * @param _WhereExpr $predicate
+     * @param _WhereExpr ...$predicates
+     */
+    public function andHaving($predicate, ...$predicates): self
+    {
+    }
+
+    /**
+     * @param _WhereExpr $predicate
+     * @param _WhereExpr ...$predicates
+     */
+    public function orHaving($predicate, ...$predicates): self
+    {
+    }
+}

--- a/tests/acceptance/QueryBuilder.feature
+++ b/tests/acceptance/QueryBuilder.feature
@@ -1,5 +1,5 @@
 Feature: QueryBuilder
-  In order to to use Doctrine QueryBuilder safely
+  In order to use Doctrine ORM QueryBuilder safely
   As a Psalm user
   I need Psalm to typecheck QueryBuilder
 
@@ -89,7 +89,7 @@ Feature: QueryBuilder
     Given I have the following code
       """
       $expr = new Expr\Andx(['a = b']);
-      builder()->having([$expr])->distinct();
+      builder()->andHaving([$expr])->distinct();
       """
     When I run Psalm
     Then I see no errors

--- a/tests/acceptance/QueryBuilderDbal.feature
+++ b/tests/acceptance/QueryBuilderDbal.feature
@@ -1,0 +1,135 @@
+Feature: QueryBuilderDbal
+  In order to use Doctrine DBAL QueryBuilder safely
+  As a Psalm user
+  I need Psalm to typecheck QueryBuilder
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin" />
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
+      """
+      <?php
+      use Doctrine\DBAL\Query\QueryBuilder;
+      use Doctrine\DBAL\Query\Expression\CompositeExpression;
+
+      /**
+       * @psalm-suppress InvalidReturnType
+       * @return QueryBuilder
+       */
+      function builder() {}
+      """
+
+  @QueryBuilderDbal
+  Scenario: Dbal QueryBuilder ::select accepts variadic arguments
+    Given I have the following code
+      """
+      builder()->select('field1', 'field2')->distinct();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @QueryBuilderDbal
+  Scenario: Dbal QueryBuilder ::select accepts array argument
+    Given I have the following code
+      """
+      builder()->select(['field1', 'field1'])->distinct();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @QueryBuilderDbal
+  Scenario: Dbal QueryBuilder ::addSelect accepts variadic arguments
+    Given I have the following code
+      """
+      builder()->addSelect('field1', 'field2')->distinct();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @QueryBuilderDbal
+  Scenario: Dbal QueryBuilder ::addSelect accepts array argument
+    Given I have the following code
+      """
+      builder()->addSelect(['field1', 'field2'])->distinct();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @QueryBuilderDbal
+  Scenario: Dbal QueryBuilder ::where, ::orWhere and ::andWhere accept variadic arguments
+    Given I have the following code
+      """
+      builder()->where('field1', 'field2')
+               ->andWhere('field1', 'field2')
+               ->orWhere('field1', 'field2')
+               ->distinct();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @QueryBuilderDbal
+  Scenario: Dbal QueryBuilder ::where, ::orWhere and ::andWhere accept CompositeExpression
+    Given I have the following code
+      """
+      $expr = builder()->expr();
+      $orx = $expr->orX();
+      $orx->add($expr->eq('field1', 1));
+      $orx->add($expr->eq('field1', 2));
+      builder()->where($orx)->andWhere($orx)->orWhere($orx)->distinct();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @QueryBuilderDbal
+  Scenario: Dbal QueryBuilder ::groupBy ::addGroupBy accept variadic arguments
+    Given I have the following code
+      """
+      builder()->groupBy('field1', 'field2')
+               ->addGroupBy('field1', 'field2')
+               ->distinct();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @QueryBuilderDbal
+  Scenario: Dbal QueryBuilder ::groupBy ::addGroupBy accept array argument
+    Given I have the following code
+      """
+      builder()->groupBy(['field1', 'field2'])
+               ->addGroupBy(['field1', 'field2'])
+               ->distinct();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @QueryBuilderDbal
+  Scenario: Dbal QueryBuilder ::having, ::orHaving and ::andHaving accept variadic arguments
+    Given I have the following code
+      """
+      builder()->having('field1', 'field2')
+               ->orHaving('field1', 'field2')
+               ->andHaving('field1', 'field2')
+               ->distinct();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @QueryBuilderDbal
+  Scenario: Dbal QueryBuilder ::having, ::orHaving and ::andHaving accept CompositeExpression
+    Given I have the following code
+      """
+      $andx = builder()->expr()->andX('a = b');
+      builder()->having($andx)->orHaving($andx)->andHaving($andx)->distinct();
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/QueryBuilderDbal.feature
+++ b/tests/acceptance/QueryBuilderDbal.feature
@@ -33,7 +33,7 @@ Feature: QueryBuilderDbal
   Scenario: Dbal QueryBuilder ::select accepts variadic arguments
     Given I have the following code
       """
-      builder()->select('field1', 'field2')->distinct();
+      builder()->select('field1', 'field2');
       """
     When I run Psalm
     Then I see no errors
@@ -42,7 +42,7 @@ Feature: QueryBuilderDbal
   Scenario: Dbal QueryBuilder ::select accepts array argument
     Given I have the following code
       """
-      builder()->select(['field1', 'field1'])->distinct();
+      builder()->select(['field1', 'field1']);
       """
     When I run Psalm
     Then I see no errors
@@ -51,7 +51,7 @@ Feature: QueryBuilderDbal
   Scenario: Dbal QueryBuilder ::addSelect accepts variadic arguments
     Given I have the following code
       """
-      builder()->addSelect('field1', 'field2')->distinct();
+      builder()->addSelect('field1', 'field2');
       """
     When I run Psalm
     Then I see no errors
@@ -60,7 +60,7 @@ Feature: QueryBuilderDbal
   Scenario: Dbal QueryBuilder ::addSelect accepts array argument
     Given I have the following code
       """
-      builder()->addSelect(['field1', 'field2'])->distinct();
+      builder()->addSelect(['field1', 'field2']);
       """
     When I run Psalm
     Then I see no errors
@@ -71,8 +71,7 @@ Feature: QueryBuilderDbal
       """
       builder()->where('field1', 'field2')
                ->andWhere('field1', 'field2')
-               ->orWhere('field1', 'field2')
-               ->distinct();
+               ->orWhere('field1', 'field2');
       """
     When I run Psalm
     Then I see no errors
@@ -85,7 +84,7 @@ Feature: QueryBuilderDbal
       $orx = $expr->orX();
       $orx->add($expr->eq('field1', 1));
       $orx->add($expr->eq('field1', 2));
-      builder()->where($orx)->andWhere($orx)->orWhere($orx)->distinct();
+      builder()->where($orx)->andWhere($orx)->orWhere($orx);
       """
     When I run Psalm
     Then I see no errors
@@ -95,8 +94,7 @@ Feature: QueryBuilderDbal
     Given I have the following code
       """
       builder()->groupBy('field1', 'field2')
-               ->addGroupBy('field1', 'field2')
-               ->distinct();
+               ->addGroupBy('field1', 'field2');
       """
     When I run Psalm
     Then I see no errors
@@ -106,8 +104,7 @@ Feature: QueryBuilderDbal
     Given I have the following code
       """
       builder()->groupBy(['field1', 'field2'])
-               ->addGroupBy(['field1', 'field2'])
-               ->distinct();
+               ->addGroupBy(['field1', 'field2']);
       """
     When I run Psalm
     Then I see no errors
@@ -118,8 +115,7 @@ Feature: QueryBuilderDbal
       """
       builder()->having('field1', 'field2')
                ->orHaving('field1', 'field2')
-               ->andHaving('field1', 'field2')
-               ->distinct();
+               ->andHaving('field1', 'field2');
       """
     When I run Psalm
     Then I see no errors
@@ -129,7 +125,7 @@ Feature: QueryBuilderDbal
     Given I have the following code
       """
       $andx = builder()->expr()->andX('a = b');
-      builder()->having($andx)->orHaving($andx)->andHaving($andx)->distinct();
+      builder()->having($andx)->orHaving($andx)->andHaving($andx);
       """
     When I run Psalm
     Then I see no errors


### PR DESCRIPTION
Basic Stub for DBAL/QueryBuilder

Fixes #45 

Please note I had to create `stubs/DBAL` subfolder since both DBAL and ORM query builders have same class name, so we can't put them into the same directory.

