### PR TITLE
Acceptance tests: fix Query\Expr feature

### DIFF
--- a/tests/acceptance/Expr.feature
+++ b/tests/acceptance/Expr.feature
@@ -1,0 +1,55 @@
+Feature: Expr
+  In order to use Doctrine Query\Expr safely
+  As a Psalm user
+  I need Psalm to typecheck Expr
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin" />
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
+      """
+      <?php
+      use Doctrine\ORM\QueryBuilder;
+      use Doctrine\ORM\Query\Expr;
+
+      /**
+       * @psalm-suppress InvalidReturnType
+       * @return QueryBuilder
+       */
+      function builder() {}
+      """
+
+  @Expr
+  Scenario: Expr::andX() accepts variadic arguments
+    Given I have the following code
+      """
+      builder()->expr()->andX(
+        'foo > bar',
+        'foo < baz'
+      );
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @Expr
+  Scenario: Expr::orX() accepts variadic arguments
+    Given I have the following code
+      """
+      $expr = builder()->expr();
+      $expr->orX(
+        $expr->eq('foo', 1),
+        $expr->eq('bar', 1)
+      );
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
Looks like acceptance tests for Query\Expr stub are missing, so I created `Expr.feature` with 2 scenarios:

- Scenario: `Expr::andX()` accepts variadic arguments
- Scenario: `Expr::orX()` accepts variadic arguments