### PR TITLE
Replace template-typeof

### DIFF
--- a/stubs/EntityManager.php
+++ b/stubs/EntityManager.php
@@ -5,38 +5,35 @@ namespace Doctrine\ORM;
 class EntityManager implements EntityManagerInterface
 {
     /**
-     * @param class-string $entityName
+     * @param class-string<T> $entityName
      *
      * @return EntityRepository<T>
      *
      * @template T
-     * @template-typeof T $entityName
      */
     public function getRepository(string $entityName)
     {
     }
 
     /**
-     * @param class-string $entityName
+     * @param class-string<T> $entityName
      * @param mixed        $id
      *
      * @return ?T
      *
      * @template T
-     * @template-typeof T $entityName
      */
     public function find(string $entityName, $id, ?int $lockMode = null, ?int $lockVersion = null)
     {
     }
 
     /**
-     * @param class-string $entityName
+     * @param class-string<T> $entityName
      * @param mixed        $id
      *
      * @return T
      *
      * @template T
-     * @template-typeof T $entityName
      */
     public function getReference(string $entityName, $id)
     {

--- a/stubs/EntityManager.php
+++ b/stubs/EntityManager.php
@@ -17,7 +17,7 @@ class EntityManager implements EntityManagerInterface
 
     /**
      * @param class-string<T> $entityName
-     * @param mixed        $id
+     * @param mixed           $id
      *
      * @return ?T
      *
@@ -29,7 +29,7 @@ class EntityManager implements EntityManagerInterface
 
     /**
      * @param class-string<T> $entityName
-     * @param mixed        $id
+     * @param mixed           $id
      *
      * @return T
      *

--- a/stubs/EntityManagerInterface.php
+++ b/stubs/EntityManagerInterface.php
@@ -7,34 +7,31 @@ use Doctrine\Common\Persistence\ObjectManager;
 interface EntityManagerInterface extends ObjectManager
 {
     /**
-     * @param class-string $entityName
+     * @param class-string<T> $entityName
      *
      * @return EntityRepository<T>
      *
      * @template T
-     * @template-typeof T $entityName
      */
     public function getRepository(string $entityName);
 
     /**
-     * @param class-string $entityName
+     * @param class-string<T> $entityName
      * @param mixed        $id
      *
      * @return ?T
      *
      * @template T
-     * @template-typeof T $entityName
      */
     public function find(string $entityName, $id, ?int $lockMode = null, ?int $lockVersion = null);
 
     /**
-     * @param class-string $entityName
+     * @param class-string<T> $entityName
      * @param mixed        $id
      *
      * @return T
      *
      * @template T
-     * @template-typeof T $entityName
      */
     public function getReference(string $entityName, $id);
 }

--- a/stubs/EntityManagerInterface.php
+++ b/stubs/EntityManagerInterface.php
@@ -17,7 +17,7 @@ interface EntityManagerInterface extends ObjectManager
 
     /**
      * @param class-string<T> $entityName
-     * @param mixed        $id
+     * @param mixed           $id
      *
      * @return ?T
      *
@@ -27,7 +27,7 @@ interface EntityManagerInterface extends ObjectManager
 
     /**
      * @param class-string<T> $entityName
-     * @param mixed        $id
+     * @param mixed           $id
      *
      * @return T
      *

--- a/stubs/ObjectManager.php
+++ b/stubs/ObjectManager.php
@@ -5,32 +5,29 @@ namespace Doctrine\Common\Persistence;
 interface ObjectManager
 {
     /**
-     * @param class-string $className
+     * @param class-string<T> $className
      *
      * @return ObjectRepository<T>
      *
      * @template T
-     * @template-typeof T $className
      */
     public function getRepository(string $className);
 
     /**
-     * @param class-string $className
+     * @param class-string<T> $className
      *
      * @return Mapping\ClassMetadata<T>
      *
      * @template T
-     * @template-typeof T $className
      */
     public function getClassMetadata(string $className);
 
     /**
-     * @param class-string $className
+     * @param class-string<T> $className
      *
      * @return ?T
      *
      * @template T
-     * @template-typeof T $className
      */
     public function find(string $className, $id);
 }

--- a/tests/acceptance/EntityRepository.feature
+++ b/tests/acceptance/EntityRepository.feature
@@ -25,7 +25,7 @@ Feature: EntityRepository
 
       /**
        * @template T
-       * @template-typeof T $entityClass
+       * @param class-string<T> $entityClass
        * @psalm-suppress InvalidReturnType
        * @return EntityRepository<T>
        */

--- a/tests/acceptance/Paginator.feature
+++ b/tests/acceptance/Paginator.feature
@@ -25,8 +25,7 @@ Feature: Paginator
 
           /**
            * @template T
-           * @template-typeof T $type
-           * @param class-string $type
+           * @param class-string<T> $type
            * @return Paginator<T>
            * @psalm-suppress InvalidReturnType
            */


### PR DESCRIPTION
According to https://github.com/vimeo/psalm/issues/1732, @template-typeof will be removed in a future version of psalm. This PR replaces @template-typeof with generics <Class> notation in the parameter.