### PR TITLE
Fix stub for DBAL ExpressionBuilder

### DIFF
--- a/stubs/DBAL/ExpressionBuilder.php
+++ b/stubs/DBAL/ExpressionBuilder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Doctrine\DBAL\Query\Expression;
+
+class ExpressionBuilder
+{
+    /**
+     * @param CompositeExpression|string ...$x
+     */
+    public function andX(...$x): CompositeExpression
+    {
+    }
+
+    /**
+     * @param CompositeExpression|string ...$x
+     */
+    public function orX(...$x): CompositeExpression
+    {
+    }
+}

--- a/tests/acceptance/ExpressionBuilder.feature
+++ b/tests/acceptance/ExpressionBuilder.feature
@@ -1,0 +1,56 @@
+Feature: Expr
+  In order to use Doctrine Dbal ExpressionBuilder safely
+  As a Psalm user
+  I need Psalm to typecheck Expr
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin" />
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
+      """
+      <?php
+      use Doctrine\DBAL\Query\QueryBuilder;
+      use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
+      use Doctrine\DBAL\Query\Expression\CompositeExpression;
+
+      /**
+       * @psalm-suppress InvalidReturnType
+       * @return QueryBuilder
+       */
+      function builder() {}
+      """
+
+  @ExpressionBuilder
+  Scenario: ExpressionBuilder::andX() accepts variadic arguments
+    Given I have the following code
+      """
+      builder()->expr()->andX(
+        'foo > bar',
+        'foo < baz'
+      );
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @ExpressionBuilder
+  Scenario: ExpressionBuilder::orX() accepts variadic arguments
+    Given I have the following code
+      """
+      $expr = builder()->expr();
+      $expr->orX(
+        $expr->eq('foo', 1),
+        $expr->eq('bar', 1)
+      );
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
Now that we have [stub](https://github.com/weirdan/doctrine-psalm-plugin/pull/45) for DBAL `Query\QueryBuilder` it also makes sense to stub the **ExpressionBuilder** (similar to ORM `Query\Expr`):

- stubbing ExpressionBuilder::andX(...$x)
- stubbing ExpressionBuilder::orX(...$x)