### PR TITLE
Allow WHERE IN clauses in the ORM QueryBuilder

### DIFF
--- a/stubs/QueryBuilder.php
+++ b/stubs/QueryBuilder.php
@@ -5,7 +5,7 @@ namespace Doctrine\ORM;
 use Doctrine\ORM\Query\Expr;
 
 /**
- * @psalm-type _WhereExpr=Expr\Base|Expr\Comparison|string
+ * @psalm-type _WhereExpr=Expr\Base|Expr\Comparison|Expr\Func|string
  * @psalm-type _SelectExpr=Expr\Func|string
  */
 class QueryBuilder

--- a/tests/acceptance/QueryBuilder.feature
+++ b/tests/acceptance/QueryBuilder.feature
@@ -135,3 +135,23 @@ Feature: QueryBuilder
       """
     When I run Psalm
     Then I see no errors
+
+  @QueryBuilder
+  Scenario: QueryBuilder ::where(), ::orWhere() and ::andWhere accept Expr\Func
+    Given I have the following code
+      """
+      $expr = new Expr\Func('id IN', [1]);
+      builder()->where($expr)->andWhere($expr)->orWhere($expr)->distinct();
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @QueryBuilder
+  Scenario: QueryBuilder ::where(), ::orWhere() and ::andWhere accept array with Expr\Func
+    Given I have the following code
+      """
+      $expr = new Expr\Func('id IN', [1]);
+      builder()->where([$expr])->andWhere([$expr])->orWhere([$expr])->distinct();
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
This PR allows `Expr\Func` to be passed into the ORM QueryBuilder’s "where" methods. This is to allow building `WHERE foo IN ("bar")` type clauses, allowing code like the following to pass:

```
$queryBuilder->where($queryBuilder->expr()->in('e.id', [1, 2]));
```

In the latest release version (0.9.0), this code would fail with:

> ERROR: ImplicitToStringCast - FooRepository.php:139:21 - Argument 1 of Doctrine\ORM\QueryBuilder::where expects Doctrine\ORM\Query\Expr\Base|Doctrine\ORM\Query\Expr\Comparison|array<array-key, Doctrine\ORM\Query\Expr\Base|Doctrine\ORM\Query\Expr\Comparison|string>|string, Doctrine\ORM\Query\Expr\Func provided with a __toString method