### PR TITLE
avoid use of GLOB_BRACE, which is not available on alpine linux

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -28,8 +28,8 @@ class Plugin implements PluginEntryPointInterface
     private function getStubFiles(): array
     {
         return array_merge(
-            glob(__DIR__ . '/stubs/*.php'),
-            glob(__DIR__ . '/stubs/DBAL/*.php'),
+            glob(__DIR__ . '/stubs/*.php') ?: [],
+            glob(__DIR__ . '/stubs/DBAL/*.php') ?: [],
         );
     }
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -12,8 +12,6 @@ use function array_merge;
 use function class_exists;
 use function glob;
 
-use const GLOB_BRACE;
-
 class Plugin implements PluginEntryPointInterface
 {
     /** @return void */
@@ -29,7 +27,10 @@ class Plugin implements PluginEntryPointInterface
     /** @return string[] */
     private function getStubFiles(): array
     {
-        return glob(__DIR__ . '/' . 'stubs/{,*/}*.php', GLOB_BRACE);
+        return array_merge(
+            glob(__DIR__ . '/stubs/*.php'),
+            glob(__DIR__ . '/stubs/DBAL/*.php'),
+        );
     }
 
     /** @return string[] */


### PR DESCRIPTION
Hi there,

`GLOB_BRACE` isn't defined on Alpine Linux, so this plugin errors if ran there.
Fixing the issue with a simple `array_merge` of the 2 stub directories for now.

Thanks

