### PR TITLE
Fix EntityManagerInterface::getReference() type hint

### DIFF
--- a/stubs/EntityManagerInterface.php
+++ b/stubs/EntityManagerInterface.php
@@ -29,7 +29,7 @@ interface EntityManagerInterface extends ObjectManager
      * @param class-string<T> $entityName
      * @param mixed           $id
      *
-     * @return T
+     * @return T|null
      *
      * @template T
      */

--- a/tests/acceptance/EntityManagerInterface.feature
+++ b/tests/acceptance/EntityManagerInterface.feature
@@ -90,7 +90,7 @@ Feature: EntityManagerInterface
     When I run Psalm
     Then I see these errors
       | Type            | Message                                      |
-      | InvalidArgument | Argument 1 of atan expects float, I provided |
+      | InvalidArgument | Argument 1 of atan expects float, I\|null provided |
     And I see no other errors
 
   @EntityManagerInterface::getReference


### PR DESCRIPTION
Original signature

```php
    /**
     * Gets a reference to the entity identified by the given type and identifier
     * without actually loading it, if the entity is not yet loaded.
     *
     * @param string $entityName The name of the entity type.
     * @param mixed  $id         The entity identifier.
     *
     * @return object|null The entity reference.
     *
     * @throws ORMException
     */
```

this fixes the stub