### PR TITLE
Allow pushes to ArrayCollection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": "^7.2|^8",
         "vimeo/psalm": "^3.6.2 || dev-master",
         "doctrine/collections": "^1.0",
-        "doctrine/orm": "^2.6" 
+        "doctrine/orm": "^2.6",
+        "composer/semver": "^1.4 || ^2.0 || ^3.0" 
     },
     "conflict": {
         "slevomat/coding-standard": "6.1.1"
@@ -40,7 +41,6 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.3",
         "codeception/codeception": "^4.0",
-        "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "weirdan/codeception-psalm-module": "^0.8.0",
         "doctrine/doctrine-bundle": "^1.11 || ^2.0",
         "phly/keep-a-changelog": "^2.1",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,7 +12,9 @@ use SimpleXMLElement;
 use function array_merge;
 use function array_search;
 use function class_exists;
+use function explode;
 use function glob;
+use function strpos;
 
 class Plugin implements PluginEntryPointInterface
 {
@@ -77,11 +79,11 @@ class Plugin implements PluginEntryPointInterface
     private function hasPackageOfVersion(string $packageName, string $constraints): bool
     {
         $packageVersion = $this->getPackageVersion($packageName);
-        if (false !== strpos($packageVersion, '@')) {
+        if (strpos($packageVersion, '@') !== false) {
             [$packageVersion] = explode('@', $packageVersion);
         }
 
-        if (0 === strpos($packageVersion, 'dev-')) {
+        if (strpos($packageVersion, 'dev-') === 0) {
             $packageVersion = '9999999-dev';
         }
 

--- a/stubs/ArrayCollection.phpstub
+++ b/stubs/ArrayCollection.phpstub
@@ -1,0 +1,51 @@
+<?php
+
+namespace Doctrine\Common\Collections;
+
+use Closure;
+
+/**
+ * @template TKey of array-key
+ * @template T
+ * @template-implements Collection<TKey,T>
+ * @template-implements Selectable<TKey,T>
+ */
+class ArrayCollection implements Collection, Selectable
+{
+    /** @param array<TKey,T> $elements */
+    public function __construct(array $elements = []) {}
+
+    /**
+     * @param array<TKey,T> $elements
+     * @return static<TKey,T>
+     */
+    protected function createFrom(array $elements) {}
+
+    /** @param TKey $offset */
+    public function offsetExists($offset) {}
+
+    /** @param TKey $offset */
+    public function offsetGet($offset) {}
+
+    /** @param TKey $offset */
+    public function offsetUnset($offset) {}
+
+    /**
+     * @param TKey|null $offset
+     * @param T $value
+     */
+    public function offsetSet($offset, $value) {}
+
+    /**
+     * @template U
+     * @param Closure(T=):U $func
+     * @return static<TKey, U>
+     */
+    public function map(Closure $func) {}
+
+    /** @psalm-return static<TKey,T> */
+    public function filter(Closure $p) {}
+
+    /** @return string */
+    public function __toString() {}
+}

--- a/stubs/Collections.phpstub
+++ b/stubs/Collections.phpstub
@@ -12,7 +12,7 @@ use ArrayAccess;
  * @template TValue
  *
  * @template-extends IteratorAggregate<TKey,TValue>
- * @template-extends ArrayAccess<TKey,TValue>
+ * @template-extends ArrayAccess<TKey|null,TValue>
  */
 interface Collection extends Countable, IteratorAggregate, ArrayAccess
 {

--- a/tests/acceptance/Collections.feature
+++ b/tests/acceptance/Collections.feature
@@ -705,6 +705,17 @@ Feature: Collections
     Then I see no errors
 
   @Collections::ArrayAccess
+  Scenario: Adding an item to array collection like an array (#66)
+    Given I have the following code
+      """
+      /** @var ArrayCollection<int,string> */
+      $c = new ArrayCollection(["a", "b", "c"]);
+      $c[] = "d";
+      """
+    When I run Psalm
+    Then I see no errors
+
+  @Collections::ArrayAccess
   Scenario: Adding an item to collection with array offset access
     Given I have the following code
       """

--- a/tests/acceptance/Collections.feature
+++ b/tests/acceptance/Collections.feature
@@ -708,7 +708,7 @@ Feature: Collections
   Scenario: Adding an item to array collection like an array (#66)
     Given I have the following code
       """
-      /** @var ArrayCollection<int,string> */
+      /** @var ArrayCollection<int,string> $c */
       $c = new ArrayCollection(["a", "b", "c"]);
       $c[] = "d";
       """


### PR DESCRIPTION
In recent `doctrine/collections` versions `Collection` extends `ArrayAccess<null|TKey,TValue>` and `ArrayCollection` narrows the `$offset` type to `TKey` (which shouldn't be allowed by LSP) for `offsetGet()`, `offsetUnset()` and `offsetExists()`.

Ideally this should be fixed in Psalm by allowing `null` in addition to `TKey` for `ArrayAccess::offsetSet()`. Then all of the above wouldn't be necessary.

Fixes #66