### PR TITLE
Fixed the return type of ObjectRepository::findAll()

### DIFF
--- a/stubs/ObjectRepository.phpstub
+++ b/stubs/ObjectRepository.phpstub
@@ -8,7 +8,7 @@ interface ObjectRepository
     /** @return ?T */
     public function find($id);
 
-    /** @return list<T> */
+    /** @return T[] */
     public function findAll();
 
     /**


### PR DESCRIPTION
Based on the changes upstream: https://github.com/doctrine/persistence/pull/104

Refs #71