### PR TITLE
Fixed ManagerRegistry deprecation/removal

### DIFF
--- a/bundle-stubs/persistence-1.3+/ServiceEntityRepository.phpstub
+++ b/bundle-stubs/persistence-1.3+/ServiceEntityRepository.phpstub
@@ -1,0 +1,20 @@
+<?php
+
+namespace Doctrine\Bundle\DoctrineBundle\Repository;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * @template T
+ * @template-extends EntityRepository<T>
+ */
+class ServiceEntityRepository extends EntityRepository implements ServiceEntityRepositoryInterface
+{
+    /**
+     * @param string $entityClass The class name of the entity this repository manages
+     */
+    public function __construct(ManagerRegistry $registry, $entityClass)
+    {
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.3",
         "codeception/codeception": "^4.0",
-        "weirdan/codeception-psalm-module": "^0.8.0",
+        "weirdan/codeception-psalm-module": "^0.9.0",
         "doctrine/doctrine-bundle": "^1.11 || ^2.0",
         "phly/keep-a-changelog": "^2.1",
         "doctrine/coding-standard": "^7.0"

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.3",
         "codeception/codeception": "^4.0",
-        "weirdan/codeception-psalm-module": "^0.9.0",
+        "weirdan/codeception-psalm-module": "^0.9.1",
         "doctrine/doctrine-bundle": "^1.11 || ^2.0",
         "phly/keep-a-changelog": "^2.1",
         "doctrine/coding-standard": "^7.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,7 +36,10 @@
     </rule>
     
     <!-- inherit rules from: -->
-    <rule ref="PSR12"/>
+    <rule ref="PSR12">
+        <!-- conflicts with other rules -->
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
+    </rule>
 
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.Files.ByteOrderMark"/>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -50,7 +50,10 @@ class Plugin implements PluginEntryPointInterface
             return [];
         }
 
-        if ($this->hasPackageOfVersion('doctrine/persistence', '>= 1.3.0')) {
+        if (
+            $this->hasPackage('doctrine/persistence')
+            && $this->hasPackageOfVersion('doctrine/persistence', '>= 1.3.0')
+        ) {
             return glob(__DIR__ . '/../' . 'bundle-stubs/persistence-1.3+/*.phpstub');
         }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -50,6 +50,10 @@ class Plugin implements PluginEntryPointInterface
             return [];
         }
 
+        if ($this->hasPackageOfVersion('doctrine/persistence', '>= 1.3.0')) {
+            return glob(__DIR__ . '/../' . 'bundle-stubs/persistence-1.3+/*.phpstub');
+        }
+
         return glob(__DIR__ . '/../' . 'bundle-stubs/*.phpstub');
     }
 

--- a/tests/acceptance/ServiceEntityRepository.feature
+++ b/tests/acceptance/ServiceEntityRepository.feature
@@ -14,41 +14,61 @@ Feature: ServiceEntityRepository
         <plugins>
           <pluginClass class="Weirdan\DoctrinePsalmPlugin\Plugin" />
         </plugins>
-        <issueHandlers>
-          <DeprecatedClass>
-            <errorLevel type="suppress">
-              <referencedClass name="Doctrine\Common\Persistence\ManagerRegistry"/>
-            </errorLevel>
-          </DeprecatedClass>
-        </issueHandlers>
       </psalm>
       """
     And I have the following code preamble
       """
       <?php
       use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-      use Doctrine\Common\Persistence\ManagerRegistry as RegistryInterface;
-
-      interface I {}
       """
 
     @ServiceEntityRepository::inheritance
     Scenario: Extending a ServiceEntityRepository
-    Given I have the following code
-    """
-    /**
-     * @method I|null find($id, $lockMode = null, $lockVersion = null)
-     * @method I|null findOneBy(array $criteria, array $orderBy = null)
-     * @method list<I>    findAll()
-     * @method list<I>    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
-     * @template-extends ServiceEntityRepository<I>
-     * @psalm-suppress PropertyNotSetInConstructor
-     */
-    class IRepository extends ServiceEntityRepository {
-      public function __construct(RegistryInterface $registry) {
-        parent::__construct($registry, I::class);
-      }
-    }
-    """
-    When I run Psalm
-    Then I see no errors
+      Given I have the "doctrine/persistence" package satisfying the "< 1.3"
+      And I have the following code
+        """
+        use Doctrine\Common\Persistence\ManagerRegistry as RegistryInterface;
+
+        interface I {}
+        /**
+         * @method I|null find($id, $lockMode = null, $lockVersion = null)
+         * @method I|null findOneBy(array $criteria, array $orderBy = null)
+         * @method list<I>    findAll()
+         * @method list<I>    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+         * @template-extends ServiceEntityRepository<I>
+         * @psalm-suppress PropertyNotSetInConstructor
+         */
+        class IRepository extends ServiceEntityRepository {
+          public function __construct(RegistryInterface $registry) {
+            parent::__construct($registry, I::class);
+          }
+        }
+        """
+      When I run Psalm
+      Then I see no errors
+
+    @ServiceEntityRepository::inheritance
+      Scenario: Extending a ServiceEntityRepository
+      Given I have the "doctrine/persistence" package satisfying the ">= 1.3"
+      And I have the following code
+        """
+        use Doctrine\Persistence\ManagerRegistry as RegistryInterface;
+
+        interface I {}
+        /**
+         * @method I|null find($id, $lockMode = null, $lockVersion = null)
+         * @method I|null findOneBy(array $criteria, array $orderBy = null)
+         * @method list<I>    findAll()
+         * @method list<I>    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+         * @template-extends ServiceEntityRepository<I>
+         * @psalm-suppress PropertyNotSetInConstructor
+         */
+        class IRepository extends ServiceEntityRepository {
+          public function __construct(RegistryInterface $registry) {
+            parent::__construct($registry, I::class);
+          }
+        }
+        """
+      When I run Psalm
+      Then I see no errors
+


### PR DESCRIPTION
`Doctrine\Common\Persistence\ManagerRegistry` was deprecated in `doctrine/persistence:1.3` and removed in `doctrine/persistence:2.0`

Fixes #70