### PR TITLE
Fix Connection::prepare return type

### DIFF
--- a/stubs/Connection.phpstub
+++ b/stubs/Connection.phpstub
@@ -44,7 +44,7 @@ class Connection implements DriverConnection
      * @throws DBALException
      * @psalm-taint-sink sql $statement
      */
-    public function prepare(string $statement): DriverStatement {}
+    public function prepare(string $statement): Statement {}
 
     /**
      * @psalm-taint-sink sql $statement


### PR DESCRIPTION
I was changing `Doctrine\DBAL\Statement::fetchAll` calls to `Doctrine\DBAL\Statement::fetchAllAssociative` (`fetchAll` is deprecated) and psalm complained:

```
ERROR: UndefinedInterfaceMethod - Method Doctrine\DBAL\Driver\Statement::fetchAllAssociative does not exist (see https://psalm.dev/181)
```

See https://github.com/doctrine/dbal/blob/f8b98ad0d08a07198cb88da824cdc09ec902a120/lib/Doctrine/DBAL/Connection.php#L1212