### PR TITLE
Improved template support on ServiceRepository

### DIFF
--- a/bundle-stubs/ServiceEntityRepository.phpstub
+++ b/bundle-stubs/ServiceEntityRepository.phpstub
@@ -12,7 +12,7 @@ use Doctrine\ORM\EntityRepository;
 class ServiceEntityRepository extends EntityRepository implements ServiceEntityRepositoryInterface
 {
     /**
-     * @param string $entityClass The class name of the entity this repository manages
+     * @param class-string<T> $entityClass The class name of the entity this repository manages
      */
     public function __construct(ManagerRegistry $registry, $entityClass)
     {

--- a/bundle-stubs/persistence-1.3+/ServiceEntityRepository.phpstub
+++ b/bundle-stubs/persistence-1.3+/ServiceEntityRepository.phpstub
@@ -12,7 +12,7 @@ use Doctrine\ORM\EntityRepository;
 class ServiceEntityRepository extends EntityRepository implements ServiceEntityRepositoryInterface
 {
     /**
-     * @param string $entityClass The class name of the entity this repository manages
+     * @param class-string<T> $entityClass The class name of the entity this repository manages
      */
     public function __construct(ManagerRegistry $registry, $entityClass)
     {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -54,6 +54,10 @@ class Plugin implements PluginEntryPointInterface
             return [];
         }
 
+        if ($this->hasPackageOfVersion('doctrine/doctrine-bundle', '>= 2.3.0')) {
+            return [];
+        }
+
         if (
             $this->hasPackage('doctrine/persistence')
             && $this->hasPackageOfVersion('doctrine/persistence', '>= 1.3.0')

--- a/tests/acceptance/ServiceEntityRepository.feature
+++ b/tests/acceptance/ServiceEntityRepository.feature
@@ -26,7 +26,6 @@ Feature: ServiceEntityRepository
          * @method I|null findOneBy(array $criteria, array $orderBy = null)
          * @method list<I>    findAll()
          * @method list<I>    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
-         * @template-extends ServiceEntityRepository<I>
          * @psalm-suppress PropertyNotSetInConstructor
          */
         class IRepository extends ServiceEntityRepository {
@@ -34,6 +33,72 @@ Feature: ServiceEntityRepository
             parent::__construct($registry, I::class);
           }
         }
+        """
+      When I run Psalm
+      Then I see no errors
+
+    @ServiceEntityRepository::generics
+      Scenario: Check template notation on ServiceEntityRepository
+      Given I have the "doctrine/persistence" package satisfying the "< 1.3"
+      And I have the following code
+        """
+        use Doctrine\Common\Persistence\ManagerRegistry as RegistryInterface;
+
+        interface I {}
+
+        /** @var RegistryInterface $registry */
+        $repository = new ServiceEntityRepository($registry, I::class);
+
+        /**
+         * @param ServiceEntityRepository<I> $argument
+         * @return void
+         */
+        function assertTemplate($argument) {}
+        assertTemplate($repository);
+        """
+      When I run Psalm
+      Then I see no errors
+
+    @ServiceEntityRepository::generics
+      Scenario: Check template notation on ServiceEntityRepository
+      Given I have the "doctrine/persistence" package satisfying the ">= 1.3"
+      And I have the following code
+        """
+        use Doctrine\Persistence\ManagerRegistry as RegistryInterface;
+
+        interface I {}
+
+        /** @var RegistryInterface $registry */
+        $repository = new ServiceEntityRepository($registry, I::class);
+
+        /**
+         * @param ServiceEntityRepository<I> $argument
+         * @return void
+        */
+        function assertTemplate($argument) {}
+        assertTemplate($repository);
+        """
+      When I run Psalm
+      Then I see no errors
+
+    @ServiceEntityRepository::generics
+      Scenario: Check template notation on ServiceEntityRepository
+      Given I have the "doctrine/doctrine-bundle" package satisfying the ">= 2.3"
+      And I have the following code
+        """
+        use Doctrine\Persistence\ManagerRegistry as RegistryInterface;
+
+        interface I {}
+
+        /** @var RegistryInterface $registry */
+        $repository = new ServiceEntityRepository($registry, I::class);
+
+        /**
+         * @param ServiceEntityRepository<I> $argument
+         * @return void
+        */
+        function assertTemplate($argument) {}
+        assertTemplate($repository);
         """
       When I run Psalm
       Then I see no errors


### PR DESCRIPTION
Don't need to type hint of a template `ServiceRepository` anymore. Template class will be obtained from second argument `class-string`