### PR TITLE
Fix doctrine collections uses

### DIFF
--- a/stubs/PersistentCollection.phpstub
+++ b/stubs/PersistentCollection.phpstub
@@ -2,6 +2,9 @@
 
 namespace Doctrine\ORM;
 
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Selectable;
+
 /**
  * @template TKey of array-key
  * @template T


### PR DESCRIPTION
First introduced in: https://github.com/psalm/psalm-plugin-doctrine/pull/99

Collection and Selectable do not exist under Doctrine ORM namespace, they are from doctrine-collections.

cc: @VincentLanglet 