### PR TITLE
@template for Query and update docs for EntityRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 tests/_output
 studio.json
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 composer.lock
 tests/_output
 studio.json
-.idea

--- a/stubs/EntityManager.phpstub
+++ b/stubs/EntityManager.phpstub
@@ -5,24 +5,6 @@ namespace Doctrine\ORM;
 class EntityManager implements EntityManagerInterface
 {
     /**
-     * @var string
-     * @psalm-supress PropertyNotSetInConstructor
-     */
-    protected $_entityName;
-
-    /**
-     * @var EntityManagerInterface
-     * @psalm-supress PropertyNotSetInConstructor
-     */
-    protected $_em;
-
-    /**
-     * @var Mapping\ClassMetadata
-     * @psalm-supress PropertyNotSetInConstructor
-     */
-    protected $_class;
-
-    /**
      * @template T
      * @param class-string<T> $entityName
      *

--- a/stubs/EntityManager.phpstub
+++ b/stubs/EntityManager.phpstub
@@ -5,6 +5,24 @@ namespace Doctrine\ORM;
 class EntityManager implements EntityManagerInterface
 {
     /**
+     * @var string
+     * @psalm-supress PropertyNotSetInConstructor
+     */
+    protected $_entityName;
+
+    /**
+     * @var EntityManagerInterface
+     * @psalm-supress PropertyNotSetInConstructor
+     */
+    protected $_em;
+
+    /**
+     * @var Mapping\ClassMetadata
+     * @psalm-supress PropertyNotSetInConstructor
+     */
+    protected $_class;
+
+    /**
      * @template T
      * @param class-string<T> $entityName
      *

--- a/stubs/EntityRepository.phpstub
+++ b/stubs/EntityRepository.phpstub
@@ -14,13 +14,22 @@ use Doctrine\Persistence\ObjectRepository;
  */
 class EntityRepository implements ObjectRepository, Selectable
 {
-    /** @var string */
+    /**
+     * @var string
+     * @psalm-supress PropertyNotSetInConstructor
+     */
     protected $_entityName;
 
-    /** @var EntityManagerInterface */
+    /**
+     * @var EntityManagerInterface
+     * @psalm-supress PropertyNotSetInConstructor
+     */
     protected $_em;
 
-    /** @var Mapping\ClassMetadata */
+    /**
+     * @var Mapping\ClassMetadata
+     * @psalm-supress PropertyNotSetInConstructor
+     */
     protected $_class;
 
     /** @param Mapping\ClassMetadata<T> $class */

--- a/stubs/EntityRepository.phpstub
+++ b/stubs/EntityRepository.phpstub
@@ -73,4 +73,12 @@ class EntityRepository implements ObjectRepository, Selectable
     public function matching(Criteria $criteria)
     {
     }
+
+    /**
+     * @return QueryBuilder<T>
+     */
+    public function createQueryBuilder($alias, $indexBy = null): QueryBuilder
+    {
+        
+    }
 }

--- a/stubs/Query.phpstub
+++ b/stubs/Query.phpstub
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\ORM;
+
+/**
+* @template T
+*/
+class Query extends AbstractQuery
+{
+    /**
+     * @param int $hydrationMode
+     *
+     * @psalm-return (
+     *    $hydrationMode is self::HYDRATE_OBJECT
+     *    ? list<T>
+     *    : mixed
+     * )
+     */
+    public function getResult($hydrationMode = self::HYDRATE_OBJECT)
+    {
+        
+    }
+}

--- a/stubs/QueryBuilder.phpstub
+++ b/stubs/QueryBuilder.phpstub
@@ -7,6 +7,7 @@ use Doctrine\ORM\Query\Expr;
 /**
  * @psalm-type _WhereExpr=Expr\Base|Expr\Comparison|Expr\Func|string
  * @psalm-type _SelectExpr=Expr\Func|string
+ * @template T
  */
 class QueryBuilder
 {
@@ -88,5 +89,14 @@ class QueryBuilder
      */
     public function orHaving($predicate, ...$predicates): self
     {
+    }
+
+
+    /**
+     * @return Query<T>
+     */
+    public function getQuery(): Query
+    {
+        
     }
 }


### PR DESCRIPTION
psalm level 1
$this->createQueryBuilder('t')->getQuery()->getResult();
Аfter these fixes the psalm stopped swearing on the repository

commit: prevent false-positive ERROR: PropertyNotSetInConstructor
moved form https://github.com/psalm/psalm-plugin-doctrine/pull/87

maybe someone else will come in handy, maybe it needs to be improved)