### PR TITLE
Prototype for repository findBy type checking.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8",
+        "composer-runtime-api": "^2.0",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "vimeo/psalm": "^4.9"
     },

--- a/src/MetadataProvider.php
+++ b/src/MetadataProvider.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Weirdan\DoctrinePsalmPlugin;
+
+use Composer\InstalledVersions;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\Persistence\Mapping\ClassMetadata as ClassMetadataInterface;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Throwable;
+
+class MetadataProvider
+{
+    /** @var MappingDriver|false|null */
+    private static $mappingDriver = null;
+
+    /** @var array<class-string, ClassMetadata|null> */
+    private static $loadedMetadata = [];
+
+    /**
+     * @param class-string $class
+     */
+    public static function get(string $class): ?ClassMetadataInterface
+    {
+        $mappingDriver = self::getMappingDriver();
+        if ($mappingDriver === null) {
+            return null;
+        }
+
+        if (!array_key_exists($class, self::$loadedMetadata)) {
+            try {
+                $metadata = new ClassMetadata($class);
+                $mappingDriver->loadMetadataForClass($class, $metadata);
+                self::$loadedMetadata[$class] = $metadata;
+            } catch (Throwable $_) {
+                self::$loadedMetadata[$class] = null; // Don't try loading again
+            }
+        }
+
+        return self::$loadedMetadata[$class];
+    }
+
+    private static function getMappingDriver(): ?MappingDriver
+    {
+        if (!InstalledVersions::isInstalled("doctrine/orm")) {
+            return null;
+        }
+
+        if (self::$mappingDriver === null) {
+            try {
+                self::$mappingDriver = new AnnotationDriver(new AnnotationReader());
+            } catch (Throwable $_) {
+                // Don't keep trying after it fails the first time.
+                self::$mappingDriver = false;
+            }
+        }
+
+        return self::$mappingDriver ?: null;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,6 +8,8 @@ use PackageVersions\Versions;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
 use SimpleXMLElement;
+use Weirdan\DoctrinePsalmPlugin\Provider\ParamsProvider\RepositoryParamsProvider;
+use Weirdan\DoctrinePsalmPlugin\Provider\ParamsProvider\RepositoryParamsProviderClassPopulator;
 use Weirdan\DoctrinePsalmPlugin\Provider\ReturnTypeProvider\CollectionFirstAndLast;
 
 use function array_merge;
@@ -18,14 +20,22 @@ use function strpos;
 
 class Plugin implements PluginEntryPointInterface
 {
+    /** @var RegistrationInterface|null */
+    public static $registrationInterface = null;
+
     public function __invoke(RegistrationInterface $psalm, ?SimpleXMLElement $config = null): void
     {
+        self::$registrationInterface = $psalm;
+
         foreach ($this->getStubFiles() as $file) {
             $psalm->addStubFile($file);
         }
 
         if (class_exists(CollectionFirstAndLast::class)) {
             $psalm->registerHooksFromClass(CollectionFirstAndLast::class);
+        }
+        if (class_exists(RepositoryParamsProviderClassPopulator::class)) {
+            $psalm->registerHooksFromClass(RepositoryParamsProviderClassPopulator::class);
         }
     }
 

--- a/src/Provider/ParamsProvider/RepositoryParamsProvider.php
+++ b/src/Provider/ParamsProvider/RepositoryParamsProvider.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Weirdan\DoctrinePsalmPlugin\Provider\ParamsProvider;
+
+use Doctrine\Persistence\ObjectRepository;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
+use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type\Atomic\TBool;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TIntRange;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TList;
+use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TMixed;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Union;
+use Weirdan\DoctrinePsalmPlugin\MetadataProvider;
+
+class RepositoryParamsProvider implements MethodParamsProviderInterface
+{
+    /** @var array<class-string> */
+    public static $classes = [];
+
+    /**
+     * @return array<string>
+     */
+    public static function getClassLikeNames(): array
+    {
+        return self::$classes;
+    }
+
+    public static function getMethodParams(MethodParamsProviderEvent $event): ?array
+    {
+        $statements_source = $event->getStatementsSource();
+        if ($statements_source === null) {
+            return null;
+        }
+        $node_type_provider = $statements_source->getNodeTypeProvider();
+        $stmt = $event->getStmt(); // Passed this down locally, Psalm would need updated for it to work
+        if ($stmt === null) {
+            return null;
+        }
+        $object_type = $node_type_provider->getType($stmt->var);
+        if ($object_type === null || !$object_type->isSingle()) {
+            return null;
+        }
+        $object_type = $object_type->getSingleAtomic();
+        if ($object_type instanceof TGenericObject) {
+            // TODO fix when using multiple parameters with different positions
+            $entity_type = $object_type->type_params[0];
+        } elseif ($object_type instanceof TNamedObject) {
+            // I didn't see a way to do this without using internal methods
+            $class_storage = $statements_source->getCodebase()->classlike_storage_provider->get($object_type->value);
+            /** @psalm-suppress UndefinedClass */
+            $entity_type = $class_storage->template_extended_params[ObjectRepository::class]["T"]
+                ?? $class_storage->template_extended_params[\Doctrine\Common\Persistence\ObjectRepository::class]["T"]
+                ?? null;
+        } else {
+            return null;
+        }
+        if ($entity_type === null || !$entity_type->isSingle()) {
+            return null;
+        }
+        $entity_type = $entity_type->getSingleAtomic();
+        if (!$entity_type instanceof TNamedObject) {
+            return null;
+        }
+        /** @var class-string */
+        $entity_class = $entity_type->value;
+
+        $entity_metadata = MetadataProvider::get($entity_class);
+        if ($entity_metadata === null) {
+            return null;
+        }
+        $properties = $entity_metadata->getFieldNames();
+        $properties = array_combine($properties, $properties);
+        if (count($properties) === 0) {
+            return null;
+        }
+        $property_types = array_map(function (string $property) use ($entity_metadata) {
+            return $entity_metadata->getTypeOfField($property);
+        }, $properties);
+
+        switch ($event->getMethodNameLowercase()) {
+            case "findby":
+                return [
+                    new FunctionLikeParameter(
+                        "criteria",
+                        false,
+                        new Union([new TKeyedArray(
+                            array_map(function (?string $property_type) {
+                                switch ($property_type) {
+                                    case "integer":
+                                        $type = new TInt();
+                                        break;
+                                    case "string":
+                                    case "text":
+                                        $type = new TString();
+                                        break;
+                                    case "boolean":
+                                        $type = new TBool();
+                                        break;
+                                    // TODO add more cases
+                                    default:
+                                        $type = new TMixed();
+                                        break;
+                                }
+                                $union = new Union([$type]);
+                                $union = new Union([$type, new TList($union)]);
+                                $union->possibly_undefined = true;
+                                return $union;
+                            }, $property_types),
+                        )])
+                    ),
+                    new FunctionLikeParameter(
+                        "orderBy",
+                        false,
+                        new Union([new TKeyedArray(
+                            array_map(function (string $_) {
+                                $type = new Union([
+                                    new TLiteralString("asc"),
+                                    new TLiteralString("ASC"),
+                                    new TLiteralString("desc"),
+                                    new TLiteralString("DESC"),
+                                ]);
+                                $type->possibly_undefined = true;
+                                return $type;
+                            }, $properties),
+                        )])
+                    ),
+                    new FunctionLikeParameter(
+                        "limit",
+                        false,
+                        new Union([new TIntRange(0, null)]),
+                    ),
+                    new FunctionLikeParameter(
+                        "offset",
+                        false,
+                        new Union([new TIntRange(0, null)]),
+                    ),
+                ];
+        }
+
+        return null;
+    }
+}

--- a/src/Provider/ParamsProvider/RepositoryParamsProviderClassPopulator.php
+++ b/src/Provider/ParamsProvider/RepositoryParamsProviderClassPopulator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Weirdan\DoctrinePsalmPlugin\Provider\ParamsProvider;
+
+use Doctrine\Persistence\ObjectRepository;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Weirdan\DoctrinePsalmPlugin\Plugin;
+
+class RepositoryParamsProviderClassPopulator implements AfterCodebasePopulatedInterface
+{
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event)
+    {
+        foreach ($event->getCodebase()->classlike_storage_provider->getAll() as $class) {
+            if (isset($class->class_implements[strtolower(ObjectRepository::class)])) {
+                RepositoryParamsProvider::$classes[] = $class->name;
+            }
+        }
+        assert(Plugin::$registrationInterface !== null);
+        if (class_exists(RepositoryParamsProvider::class)) {
+            Plugin::$registrationInterface->registerHooksFromClass(RepositoryParamsProvider::class);
+        }
+    }
+}


### PR DESCRIPTION
I've wanted to have `ObjectRepository::findBy` type check the criteria for a while now, and I finally got around to working out a prototype. There are still several major problems:

1. Psalm doesn't support this use case very well, `RepositoryParamsProviderClassPopulator` is a workaround that severely abuses the api to allow providing return types for inherited methods.
2. Psalm doesn't give any info about the object the method is being called on. I modified Psalm locally to pass the `MethodCall` statement and it works fine.
3. Doctrine really doesn't play nice with this either. Most of the Doctrine api requires you to have an `EntityManager`, which requires a database connection, which I would like to avoid. Even when creating and populating the `ClassMetadata` directly it uses the Reflection api, which means everything being analyzed has to be autoloadable.
4. Due to 3, I have no idea how to go about properly unit testing this.

All that being said, I tested it on a Symfony project and it worked quite well. Unfortunately I'm not really sure where to go from here.