### PR TITLE
fix query stub

### DIFF
--- a/stubs/EntityRepository.phpstub
+++ b/stubs/EntityRepository.phpstub
@@ -73,12 +73,4 @@ class EntityRepository implements ObjectRepository, Selectable
     public function matching(Criteria $criteria)
     {
     }
-
-    /**
-     * @return QueryBuilder<T>
-     */
-    public function createQueryBuilder($alias, $indexBy = null): QueryBuilder
-    {
-        
-    }
 }

--- a/stubs/Query.phpstub
+++ b/stubs/Query.phpstub
@@ -8,7 +8,7 @@ namespace Doctrine\ORM;
 class Query extends AbstractQuery
 {
     /**
-     * @param int $hydrationMode
+     * @param int|string $hydrationMode
      *
      * @psalm-return (
      *    $hydrationMode is self::HYDRATE_OBJECT

--- a/stubs/QueryBuilder.phpstub
+++ b/stubs/QueryBuilder.phpstub
@@ -7,7 +7,6 @@ use Doctrine\ORM\Query\Expr;
 /**
  * @psalm-type _WhereExpr=Expr\Base|Expr\Comparison|Expr\Func|string
  * @psalm-type _SelectExpr=Expr\Func|string
- * @template T
  */
 class QueryBuilder
 {
@@ -93,7 +92,7 @@ class QueryBuilder
 
 
     /**
-     * @return Query<T>
+     * @return Query<mixed>
      */
     public function getQuery(): Query
     {


### PR DESCRIPTION
Hi @orklah, this pr allows a query of MyEntity to return something else than Query<MyEntity>, if I select `myEntity.label` for instance. A queryBuilder could return any type of query.
That is why there is no template in phpstan: https://github.com/phpstan/phpstan-doctrine/blob/master/stubs/ORM/QueryBuilder.stub

Btw the type of the hydrationMode was wrong: https://github.com/doctrine/orm/blob/2.11.x/lib/Doctrine/ORM/AbstractQuery.php#L864.