### PR TITLE
Return a generic array in Query

### DIFF
--- a/stubs/Query.phpstub
+++ b/stubs/Query.phpstub
@@ -3,7 +3,8 @@
 namespace Doctrine\ORM;
 
 /**
-* @template T
+* @template TKey as array-key
+* @template TValue
 */
 class Query extends AbstractQuery
 {
@@ -12,7 +13,7 @@ class Query extends AbstractQuery
      *
      * @psalm-return (
      *    $hydrationMode is self::HYDRATE_OBJECT
-     *    ? array<T>
+     *    ? array<TKey, TValue>
      *    : mixed
      * )
      */

--- a/stubs/Query.phpstub
+++ b/stubs/Query.phpstub
@@ -12,7 +12,7 @@ class Query extends AbstractQuery
      *
      * @psalm-return (
      *    $hydrationMode is self::HYDRATE_OBJECT
-     *    ? list<T>
+     *    ? array<T>
      *    : mixed
      * )
      */


### PR DESCRIPTION
This may not be a list, it may be an indexed array. Example:
https://github.com/doctrine/orm/blob/bfed8cb6ed448f4ab1ea3fff06e4d6c44439e4ef/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php#L491

This is a potential error like
```
ERROR: RedundantFunctionCallGivenDocblockType - src/*** - The call to array_values is unnecessary given the list docblock type list<mixed> (see https://psalm.dev/281)
        return array_values($result);
```