### PR TITLE
Improve `Collection` `::first()` and `::last()` return type provider.

### DIFF
--- a/src/Provider/ReturnTypeProvider/CollectionFirstAndLast.php
+++ b/src/Provider/ReturnTypeProvider/CollectionFirstAndLast.php
@@ -12,8 +12,10 @@ use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type;
 
+use function array_reverse;
 use function count;
 use function current;
+use function implode;
 use function is_string;
 
 class CollectionFirstAndLast implements MethodReturnTypeProviderInterface
@@ -34,19 +36,21 @@ class CollectionFirstAndLast implements MethodReturnTypeProviderInterface
         }
 
         // Get variable or property string
-        $varStmt = $stmt->var;
+        $varStmt  = $stmt->var;
         $varParts = [];
         while ($varStmt instanceof PropertyFetch && $varStmt->name instanceof Identifier) {
             $varParts[] = $varStmt->name->name;
-            $varStmt = $varStmt->var;
+            $varStmt    = $varStmt->var;
         }
-        if (!$varStmt instanceof Variable || !is_string($varStmt->name)) {
+
+        if (! $varStmt instanceof Variable || ! is_string($varStmt->name)) {
             return null;
         }
-        $varParts[] = $varStmt->name;
-        $scopedVarName = '$' . implode("->", array_reverse($varParts)) . '->isempty()';
 
-        if ($event->getMethodNameLowercase() === "add") {
+        $varParts[]    = $varStmt->name;
+        $scopedVarName = '$' . implode('->', array_reverse($varParts)) . '->isempty()';
+
+        if ($event->getMethodNameLowercase() === 'add') {
             $event->getContext()->vars_in_scope[$scopedVarName] = Type::getFalse();
 
             return null;

--- a/tests/acceptance/Collections.feature
+++ b/tests/acceptance/Collections.feature
@@ -298,6 +298,38 @@ Feature: Collections
       | InvalidScalarArgument | Argument 1 of atan expects float, string provided |
     And I see no other errors
 
+  @Collection::first
+  Scenario: Getting first item of a collection that has been added to
+    Given I have the following code
+      """
+      /** @var Collection<int,string> */
+      $c = new ArrayCollection([]);
+      $c->add("a");
+      $c->add("b");
+      $c->add("c");
+      atan($c->first());
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type                  | Message                                                  |
+      | InvalidScalarArgument | Argument 1 of atan expects float, string provided |
+    And I see no other errors
+
+  @Collection::first
+  Scenario: Getting first item of a collection that is a deeply nested property
+    Given I have the following code
+      """
+      /** @var object{bar: object{baz: object{a: object{b: object{c: Collection<int,string>}}}}} $foo */
+      if (!$foo->bar->baz->a->b->c->isEmpty()) {
+        atan($foo->bar->baz->a->b->c->first());
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type                  | Message                                                  |
+      | InvalidScalarArgument | Argument 1 of atan expects float, string provided |
+    And I see no other errors
+
   @Collection::last
   Scenario: Getting last item of the collection
     Given I have the following code


### PR DESCRIPTION
Infer non-empty when `Collection::add()` has been called, and make provider work for properties as well as variables.