### PR TITLE
Fix CI issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "require": {
         "php": "^7.2 || ^8",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
-        "vimeo/psalm": "^4.9"
+        "vimeo/psalm": "^4.9",
+        "phpstan/phpdoc-parser": "~1.5.0"
     },
     "conflict": {
         "doctrine/collections": "<1.6",
@@ -46,7 +47,10 @@
         "weirdan/codeception-psalm-module": "^0.13.1"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "psalm": {


### PR DESCRIPTION
This adds a requirement for phpstan/phpdoc-parser to ~1.5.0 to prevent installing 1.6 which causes a crash due to slevomat/coding-standard#1379. Once doctrine/coding-standard has a new 9.0.x release (that requires slevomat/coding-standard ^8 with the fix), that should become the minimum for that package and the phpstan/phpdoc-parser requirement should be removed.