### PR TITLE
Fix low deps tests.

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -13,6 +13,6 @@ class AcceptanceTester extends Actor
      */
     public function iHaveEmptyComposerlock(): void
     {
-        $this->writeToFile('tests/_run/composer.lock', '{}');
+        $this->writeToFile('tests/_run/composer.lock', '{"packages":[]}');
     }
 }


### PR DESCRIPTION
Composer expects a "packages" key to exist in composer.lock, not having it there was causing an error in FallbackVersions.php.