### PR TITLE
Mark `Selectable::matching` as a mutation free

### DIFF
--- a/stubs/Collections.phpstub
+++ b/stubs/Collections.phpstub
@@ -170,6 +170,7 @@ interface Collection extends Countable, IteratorAggregate, ArrayAccess
 interface Selectable
 {
     /**
+     * @psalm-mutation-free
      * @return Collection<TKey,TValue>
      */
     public function matching(Criteria $criteria);


### PR DESCRIPTION
It returns a new collection by the contract:
https://github.com/doctrine/collections/blob/1.6.x/lib/Doctrine/Common/Collections/Selectable.php#L24