### PR TITLE
Remove version constraint for phpstan/phpdoc-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "require": {
         "php": "^7.2 || ^8",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
-        "vimeo/psalm": "^4.28",
-        "phpstan/phpdoc-parser": "~1.5.0"
+        "vimeo/psalm": "^4.28"
     },
     "conflict": {
         "doctrine/collections": "<1.8",


### PR DESCRIPTION
The version constraint for `phpstan/phpdoc-parser` introduced in https://github.com/psalm/psalm-plugin-doctrine/pull/120 can be removed again, because the fix was merged upstream in https://github.com/slevomat/coding-standard/issues/1379.

Fixes #127 