### PR TITLE
Fix Connection::prepare() return type

### DIFF
--- a/stubs/Connection.phpstub
+++ b/stubs/Connection.phpstub
@@ -45,7 +45,7 @@ class Connection implements DriverConnection
      * @throws DBALException
      * @psalm-taint-sink sql $statement
      */
-    public function prepare(string $statement): DriverStatement {}
+    public function prepare(string $statement): Statement {}
 
     /**
      * @psalm-taint-sink sql $statement


### PR DESCRIPTION
I've checked doctrine/dbal since versions 2.6, none returns Driver\Statement.
https://github.com/doctrine/dbal/blob/v2.6.0/lib/Doctrine/DBAL/Connection.php#L856
https://github.com/doctrine/dbal/blob/3.6.x/src/Connection.php#L1044